### PR TITLE
fix(GameService): use cache for activeGames instead of Map

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,3 +14,7 @@ netty:
 log:
   level:
     com.faforever: INFO
+game:
+  cache:
+    expiration-minutes: ${GAME_CACHE_EXPIRATION_MINUTES:240} # Default: 4 Hours
+    max-size: ${GAME_CACHE_MAX_SIZE:10000} # Default: 10_000 Games


### PR DESCRIPTION
The goal of this PR is to switch the usage of `ConcurrentHashMap` for `com.faforever.ice.telemetry.GameService#activeGames`, to Caffeine Cache implementation, which will resolve the memory leak issue.

(Also, Caffeine uses [LFU cache-eviction policy](https://github.com/ben-manes/caffeine/wiki/Efficiency), which prioritizes eviction of least-accessed entries)